### PR TITLE
Fixes to GH Actions

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -19,7 +19,7 @@ jobs:
         ref: ${{ inputs.git-ref }}
     - name: Create release branch
       env:
-        - RELEASE_VERSION: release-${{ inputs.release-version }}
+        RELEASE_VERSION: release-${{ inputs.release-version }}
       run: |
         git branch ${RELEASE_VERSION}
         git switch ${RELEASE_VERSION}

--- a/workflow-templates/release-branch.yml
+++ b/workflow-templates/release-branch.yml
@@ -10,7 +10,6 @@ on:
         description: "Semantic version for the release branch (vX.Y format)"
 jobs:
   create-release-branch:
-    runs-on: ubuntu-latest
     permissions:
       contents: write
     uses: adambkaplan/.github/workflows/release-branch.yml@main


### PR DESCRIPTION
- `env` takes a map, not an array
- `runs-on` cannot be used with reusable workflows